### PR TITLE
Fix mixed content warnings

### DIFF
--- a/food_ratings/templates/rating.html
+++ b/food_ratings/templates/rating.html
@@ -181,8 +181,8 @@
 var point = {{ location.point|default('undefined') }};
 if (point) {
   var map = L.map('map-canvas').setView(point, 17);
-  L.tileLayer('http://{s}.tile.osm.org/{z}/{x}/{y}.png', {
-      attribution: '&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
+  L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+      attribution: '&copy; <a href="https://openstreetmap.org/copyright">OpenStreetMap</a> contributors'
       }).addTo(map);
   map.scrollWheelZoom.disable();
   L.marker([ {{ address.latitude }}, {{address.longitude }}]).addTo(map)

--- a/food_ratings/templates/rating.html
+++ b/food_ratings/templates/rating.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 
 {% block head_end %}
-  <link rel="stylesheet" href="http://cdn.leafletjs.com/leaflet/v0.7.7/leaflet.css" />
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.7/leaflet.css" />
 {% endblock %}
 
 {% block content %}
@@ -122,7 +122,7 @@
 
 
   <div class="row">
-    <div class="large-10 columns"">
+    <div class="large-10 columns">
 
       <h2 class="heading-small">This page uses data from a number of different registers</h2>
       <ul class="accordion" data-accordion>
@@ -176,7 +176,7 @@
 
 {% block body_end %}
 
-<script src="http://cdn.leafletjs.com/leaflet/v0.7.7/leaflet.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.7/leaflet.js"></script>
 <script>
 var point = {{ location.point|default('undefined') }};
 if (point) {

--- a/food_ratings/templates/results.html
+++ b/food_ratings/templates/results.html
@@ -133,7 +133,7 @@
                 </label>
               </div>
               <div class="large-8 columns">
-                 <img src="http://placehold.it/500x300">
+                 <img src="https://placehold.it/500x300">
                <div id="map-canvas" style="display: none"></div>
 
               </div>


### PR DESCRIPTION
When deploying this to an https site, assets served over http cause warnings.

This updates assets to pull them from https URLs everywhere instead, so that the demo works whether served over http or https.
