### PR TITLE
Bug: Ratings are displayed in sorted order by newest first

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,4 +43,4 @@ docs/_build
 
 .webassets-cache
 
-
+.idea

--- a/food_ratings/frontend/views.py
+++ b/food_ratings/frontend/views.py
@@ -84,7 +84,7 @@ def search():
         premises = _entry('premises', result['premises'])
         result['address'] = _entry('address', premises['address'])
         ratings = _index('food-premises-rating', 'food-premises', result['food-premises'])
-        ratings = sorted(ratings, key=lambda item: (item.get('start-date', '')))
+        ratings = sorted(ratings, key=lambda item: (item.get('start-date', '')), reverse=True)
         if ratings:
             result['rating'] = ratings[-1]
 


### PR DESCRIPTION
food ratings were sorted in wrong order because of which the search page was displaying the old rating first. changed the sorting order to solve the issue.
